### PR TITLE
Scaffold site and prompts across sprints 1-5

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,12 @@
+# Component Content Patterns
+
+## Header
+- Title: [INSERT SITE TITLE]
+
+## Footer
+- Text: [INSERT FOOTER]
+
+## Card
+- Title: [INSERT CARD TITLE]
+- Summary: [INSERT CARD SUMMARY]
+- Link: [INSERT LINK]

--- a/docs/contrast_notes.md
+++ b/docs/contrast_notes.md
@@ -1,0 +1,3 @@
+# Contrast Check Notes
+- Tested sample colors for AA compliance.
+- Dark mode variables available in CSS.

--- a/docs/css_qa_notes.md
+++ b/docs/css_qa_notes.md
@@ -1,0 +1,3 @@
+# CSS QA Notes
+- Checked cross-browser in placeholders.
+- Tokens considered stable.

--- a/docs/editorial_checklist.md
+++ b/docs/editorial_checklist.md
@@ -1,0 +1,4 @@
+# Editorial Checklist
+- [ ] Verify placeholders are used for all content
+- [ ] Check grammar placeholders
+- [ ] Review metadata fields

--- a/docs/final_review.md
+++ b/docs/final_review.md
@@ -1,0 +1,4 @@
+# Final Review
+- [ ] IA complete
+- [ ] Content placeholders verified
+- [ ] Accessibility checklist complete

--- a/docs/ia.md
+++ b/docs/ia.md
@@ -1,0 +1,12 @@
+# Information Architecture
+
+## Pages
+- Home (`index.html`): [INSERT TITLE]
+- Episodes (`episodes.html`): [INSERT EPISODE LIST]
+- Episode Detail (`episodes/episode-template.html`): [INSERT EPISODE DETAILS]
+- About (`about.html`): [INSERT ABOUT CONTENT]
+
+## Content Placeholders
+- Title: [INSERT TITLE]
+- Summary: [INSERT SUMMARY]
+- Metadata: [INSERT METADATA FIELDS]

--- a/docs/wireframes/about.md
+++ b/docs/wireframes/about.md
@@ -1,0 +1,3 @@
+# Wireframe: About
+
+Placeholder description for about page layout.

--- a/docs/wireframes/episode.md
+++ b/docs/wireframes/episode.md
@@ -1,0 +1,3 @@
+# Wireframe: Episode
+
+Placeholder description for episode detail page.

--- a/docs/wireframes/index.md
+++ b/docs/wireframes/index.md
@@ -1,0 +1,3 @@
+# Wireframe: Index
+
+Description of layout with hero and list sections.

--- a/prompts/accessibility_checklist.md
+++ b/prompts/accessibility_checklist.md
@@ -1,0 +1,5 @@
+# Accessibility Checklist
+- [ ] Keyboard navigation covers all interactive elements
+- [ ] Color contrast meets WCAG AA
+- [ ] Images include alt text placeholders
+- [ ] Pages contain semantic landmarks

--- a/prompts/content_template.md
+++ b/prompts/content_template.md
@@ -1,0 +1,11 @@
+# Content Template Master Prompt
+
+Use this template to generate placeholder-safe content.
+
+## Inputs
+- Title: [INSERT TITLE]
+- Summary: [INSERT SUMMARY]
+- Body: [INSERT BODY]
+
+## Output
+Produce markdown with the provided fields, replacing each with the placeholder values.

--- a/prompts/episode_outline_prompt.md
+++ b/prompts/episode_outline_prompt.md
@@ -1,0 +1,9 @@
+# Episode Outline Prompt
+
+Generate an outline with placeholders only.
+
+Inputs:
+- Episode title: [INSERT TITLE]
+
+Output:
+- List of beats with `[INSERT TEXT]` placeholders.

--- a/prompts/episode_summary_prompt.md
+++ b/prompts/episode_summary_prompt.md
@@ -1,0 +1,10 @@
+# Episode Summary Prompt
+
+Generate a short summary with placeholders.
+
+Inputs:
+- Episode title: [INSERT TITLE]
+- Key points: [INSERT POINTS]
+
+Output:
+- Paragraph with `[INSERT SUMMARY]` placeholder.

--- a/prompts/handoff_brief.md
+++ b/prompts/handoff_brief.md
@@ -1,0 +1,4 @@
+# Handoff Brief
+
+Add content by replacing placeholders in `docs/` and `site/`.
+Use `prompts/promote.ps1 -DryRun` before promoting to `/root/`.

--- a/prompts/promote.ps1
+++ b/prompts/promote.ps1
@@ -1,0 +1,11 @@
+param([switch]$DryRun)
+
+$src = "./site"
+$dst = "./root/site"
+
+if ($DryRun) {
+  Write-Host "Dry run: copying $src to $dst"
+} else {
+  Copy-Item -Path $src/* -Destination $dst -Recurse -Force
+  Write-Host "Promoted site files to root"
+}

--- a/root/site/about.html
+++ b/root/site/about.html
@@ -1,0 +1,43 @@
+<!-- Wireframe: docs/wireframes/about.md -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="[INSERT DESCRIPTION]">
+  <meta property="og:title" content="[INSERT TITLE]">
+  <meta property="og:description" content="[INSERT DESCRIPTION]">
+  <script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "[INSERT TITLE]"
+  }</script>
+  <title>[INSERT ABOUT TITLE]</title>
+  <link rel="canonical" href="[INSERT CANONICAL URL]">
+  <link rel="stylesheet" href="site.css">
+</head>
+<body>
+  <!-- include components/header.html -->
+  <header role="banner">
+    <h1>[INSERT SITE TITLE]</h1>
+    <nav aria-label="Primary">
+      <button id="nav-toggle" aria-expanded="false">Menu</button>
+      <ul id="nav-menu" class="nav-list">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="episodes.html">Episodes</a></li>
+        <li><a href="about.html">About</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main id="main-content">
+    <section aria-label="About">
+      <h2>[INSERT ABOUT HEADING]</h2>
+      <p>[INSERT ABOUT SUMMARY]</p>
+    </section>
+  </main>
+  <!-- include components/footer.html -->
+  <footer role="contentinfo">
+    <p>[INSERT FOOTER]</p>
+  </footer>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/root/site/episodes.html
+++ b/root/site/episodes.html
@@ -1,0 +1,52 @@
+<!-- Wireframe: docs/wireframes/episode.md -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="[INSERT DESCRIPTION]">
+  <meta property="og:title" content="[INSERT TITLE]">
+  <meta property="og:description" content="[INSERT DESCRIPTION]">
+  <script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "[INSERT TITLE]"
+  }</script>
+  <title>[INSERT EPISODES TITLE]</title>
+  <link rel="canonical" href="[INSERT CANONICAL URL]">
+  <link rel="stylesheet" href="site.css">
+</head>
+<body>
+  <!-- include components/header.html -->
+  <header role="banner">
+    <h1>[INSERT SITE TITLE]</h1>
+    <nav aria-label="Primary">
+      <button id="nav-toggle" aria-expanded="false">Menu</button>
+      <ul id="nav-menu" class="nav-list">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="episodes.html">Episodes</a></li>
+        <li><a href="about.html">About</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main id="main-content">
+    <section aria-label="Hero">
+      <h2>[INSERT EPISODES HERO]</h2>
+      <p>[INSERT EPISODES INTRO]</p>
+    </section>
+    <section aria-label="Episode List">
+      <!-- include components/card.html -->
+      <article class="card">
+        <h3>[INSERT EPISODE TITLE]</h3>
+        <p>[INSERT EPISODE SUMMARY]</p>
+        <a href="?episode=1">[PREVIEW EPISODE]</a>
+      </article>
+      <div id="episode-preview"></div>
+    </section>
+  </main>
+  <!-- include components/footer.html -->
+  <footer role="contentinfo">
+    <p>[INSERT FOOTER]</p>
+  </footer>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/root/site/episodes/episode-template.html
+++ b/root/site/episodes/episode-template.html
@@ -1,0 +1,43 @@
+<!-- Wireframe: docs/wireframes/episode.md -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="[INSERT DESCRIPTION]">
+  <meta property="og:title" content="[INSERT TITLE]">
+  <meta property="og:description" content="[INSERT DESCRIPTION]">
+  <script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "[INSERT TITLE]"
+  }</script>
+  <title>[INSERT EPISODE TITLE]</title>
+  <link rel="canonical" href="[INSERT CANONICAL URL]">
+  <link rel="stylesheet" href="../site.css">
+</head>
+<body>
+  <!-- include ../components/header.html -->
+  <header role="banner">
+    <h1>[INSERT SITE TITLE]</h1>
+    <nav aria-label="Primary">
+      <button id="nav-toggle" aria-expanded="false">Menu</button>
+      <ul id="nav-menu" class="nav-list">
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../episodes.html">Episodes</a></li>
+        <li><a href="../about.html">About</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main id="main-content">
+    <article aria-label="Episode Detail">
+      <h2>[INSERT EPISODE TITLE]</h2>
+      <p>[INSERT EPISODE SUMMARY]</p>
+    </article>
+  </main>
+  <!-- include ../components/footer.html -->
+  <footer role="contentinfo">
+    <p>[INSERT FOOTER]</p>
+  </footer>
+  <script src="../main.js"></script>
+</body>
+</html>

--- a/root/site/index.html
+++ b/root/site/index.html
@@ -1,0 +1,50 @@
+<!-- Wireframe: docs/wireframes/index.md -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="[INSERT DESCRIPTION]">
+  <meta property="og:title" content="[INSERT TITLE]">
+  <meta property="og:description" content="[INSERT DESCRIPTION]">
+  <script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "[INSERT TITLE]"
+  }</script>
+  <title>[INSERT TITLE]</title>
+  <link rel="canonical" href="[INSERT CANONICAL URL]">
+  <link rel="stylesheet" href="site.css">
+</head>
+<body>
+  <!-- include components/header.html -->
+  <header role="banner">
+    <h1>[INSERT SITE TITLE]</h1>
+    <nav aria-label="Primary">
+      <button id="nav-toggle" aria-expanded="false">Menu</button>
+      <ul id="nav-menu" class="nav-list">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="episodes.html">Episodes</a></li>
+        <li><a href="about.html">About</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main id="main-content">
+    <section aria-label="Hero">
+      <h2>[INSERT HERO TITLE]</h2>
+      <p>[INSERT HERO SUMMARY]</p>
+    </section>
+    <section aria-label="List">
+      <!-- include components/card.html -->
+      <article class="card">
+        <h3>[INSERT CARD TITLE]</h3>
+        <p>[INSERT CARD SUMMARY]</p>
+      </article>
+    </section>
+  </main>
+  <!-- include components/footer.html -->
+  <footer role="contentinfo">
+    <p>[INSERT FOOTER]</p>
+  </footer>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/root/site/sitemap.xml
+++ b/root/site/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>[INSERT URL]</loc></url>
+</urlset>

--- a/site/about.html
+++ b/site/about.html
@@ -1,0 +1,34 @@
+<!-- Wireframe: docs/wireframes/about.md -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>[INSERT ABOUT TITLE]</title>
+  <link rel="stylesheet" href="site.css">
+</head>
+<body>
+  <!-- include components/header.html -->
+  <header role="banner">
+    <h1>[INSERT SITE TITLE]</h1>
+    <nav aria-label="Primary">
+      <button id="nav-toggle" aria-expanded="false">Menu</button>
+      <ul id="nav-menu" class="nav-list">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="episodes.html">Episodes</a></li>
+        <li><a href="about.html">About</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main id="main-content">
+    <section aria-label="About">
+      <h2>[INSERT ABOUT HEADING]</h2>
+      <p>[INSERT ABOUT SUMMARY]</p>
+    </section>
+  </main>
+  <!-- include components/footer.html -->
+  <footer role="contentinfo">
+    <p>[INSERT FOOTER]</p>
+  </footer>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/site/components/card.html
+++ b/site/components/card.html
@@ -1,0 +1,5 @@
+<article class="card">
+  <h3>[INSERT CARD TITLE]</h3>
+  <p>[INSERT CARD SUMMARY]</p>
+  <a href="[INSERT LINK]">[INSERT LINK TEXT]</a>
+</article>

--- a/site/components/footer.html
+++ b/site/components/footer.html
@@ -1,0 +1,3 @@
+<footer role="contentinfo">
+  <p>[INSERT FOOTER]</p>
+</footer>

--- a/site/components/header.html
+++ b/site/components/header.html
@@ -1,0 +1,3 @@
+<header role="banner">
+  <h1>[INSERT SITE TITLE]</h1>
+</header>

--- a/site/episodes.html
+++ b/site/episodes.html
@@ -1,0 +1,43 @@
+<!-- Wireframe: docs/wireframes/episode.md -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>[INSERT EPISODES TITLE]</title>
+  <link rel="stylesheet" href="site.css">
+</head>
+<body>
+  <!-- include components/header.html -->
+  <header role="banner">
+    <h1>[INSERT SITE TITLE]</h1>
+    <nav aria-label="Primary">
+      <button id="nav-toggle" aria-expanded="false">Menu</button>
+      <ul id="nav-menu" class="nav-list">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="episodes.html">Episodes</a></li>
+        <li><a href="about.html">About</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main id="main-content">
+    <section aria-label="Hero">
+      <h2>[INSERT EPISODES HERO]</h2>
+      <p>[INSERT EPISODES INTRO]</p>
+    </section>
+    <section aria-label="Episode List">
+      <!-- include components/card.html -->
+      <article class="card">
+        <h3>[INSERT EPISODE TITLE]</h3>
+        <p>[INSERT EPISODE SUMMARY]</p>
+        <a href="?episode=1">[PREVIEW EPISODE]</a>
+      </article>
+      <div id="episode-preview"></div>
+    </section>
+  </main>
+  <!-- include components/footer.html -->
+  <footer role="contentinfo">
+    <p>[INSERT FOOTER]</p>
+  </footer>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/site/episodes/episode-template.html
+++ b/site/episodes/episode-template.html
@@ -1,0 +1,34 @@
+<!-- Wireframe: docs/wireframes/episode.md -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>[INSERT EPISODE TITLE]</title>
+  <link rel="stylesheet" href="../site.css">
+</head>
+<body>
+  <!-- include ../components/header.html -->
+  <header role="banner">
+    <h1>[INSERT SITE TITLE]</h1>
+    <nav aria-label="Primary">
+      <button id="nav-toggle" aria-expanded="false">Menu</button>
+      <ul id="nav-menu" class="nav-list">
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../episodes.html">Episodes</a></li>
+        <li><a href="../about.html">About</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main id="main-content">
+    <article aria-label="Episode Detail">
+      <h2>[INSERT EPISODE TITLE]</h2>
+      <p>[INSERT EPISODE SUMMARY]</p>
+    </article>
+  </main>
+  <!-- include ../components/footer.html -->
+  <footer role="contentinfo">
+    <p>[INSERT FOOTER]</p>
+  </footer>
+  <script src="../main.js"></script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,43 @@
+<!-- Wireframe: docs/wireframes/index.md -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>[INSERT TITLE]</title>
+  <link rel="stylesheet" href="site.css">
+</head>
+<body>
+  <!-- include components/header.html -->
+  <header role="banner">
+    <h1>[INSERT SITE TITLE]</h1>
+    <nav aria-label="Primary">
+      <button id="nav-toggle" aria-expanded="false">Menu</button>
+      <ul id="nav-menu" class="nav-list">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="episodes.html">Episodes</a></li>
+        <li><a href="about.html">About</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main id="main-content">
+    <section aria-label="Hero">
+    <button data-collapsible data-target="extra" aria-expanded="false">Toggle</button>
+    <div id="extra" class="u-hidden">[INSERT EXTRA]</div>
+      <h2>[INSERT HERO TITLE]</h2>
+      <p>[INSERT HERO SUMMARY]</p>
+    </section>
+    <section aria-label="List">
+      <!-- include components/card.html -->
+      <article class="card">
+        <h3>[INSERT CARD TITLE]</h3>
+        <p>[INSERT CARD SUMMARY]</p>
+      </article>
+    </section>
+  </main>
+  <!-- include components/footer.html -->
+  <footer role="contentinfo">
+    <p>[INSERT FOOTER]</p>
+  </footer>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/site/main.js
+++ b/site/main.js
@@ -1,0 +1,52 @@
+function initNavigation() {
+  const toggle = document.getElementById('nav-toggle');
+  const menu = document.getElementById('nav-menu');
+  if (!toggle || !menu) return;
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    menu.classList.toggle('u-hidden', expanded);
+  });
+}
+
+function loadEpisodeTemplate() {
+  const preview = document.getElementById('episode-preview');
+  if (!preview) return;
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('episode')) {
+    fetch('episodes/episode-template.html')
+      .then(r => r.text())
+      .then(html => {
+        preview.innerHTML = html;
+      });
+  }
+}
+
+function enhanceComponents() {
+  document.querySelectorAll('img[data-src]').forEach(img => {
+    img.setAttribute('loading', 'lazy');
+    img.src = img.dataset.src;
+  });
+}
+
+function initCollapsibles() {
+  document.querySelectorAll('[data-collapsible]').forEach(btn => {
+    const target = document.getElementById(btn.getAttribute('data-target'));
+    if (!target) return;
+    btn.addEventListener('click', () => {
+      const hidden = target.classList.toggle('u-hidden');
+      btn.setAttribute('aria-expanded', String(!hidden));
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initNavigation();
+  loadEpisodeTemplate();
+  enhanceComponents();
+  initCollapsibles();
+});
+
+function updatePreview() {
+  console.log('Update preview placeholder');
+}

--- a/site/site.css
+++ b/site/site.css
@@ -1,0 +1,67 @@
+:root {
+  --color-background: #ffffff;
+  --color-text: #000000;
+  --spacing-unit: 1rem;
+  --font-base: Arial, sans-serif;
+  --header-bg: #f0f0f0;
+  --link-color: #0066cc;
+  --dark-background: #000000;
+  --dark-text: #ffffff;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-base);
+  color: var(--color-text);
+  background: var(--color-background);
+}
+
+.nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: var(--spacing-unit);
+}
+
+h1 { font-size: 2rem; }
+h2 { font-size: 1.5rem; }
+h3 { font-size: 1.25rem; }
+
+.card {
+  border: 1px solid #ccc;
+  padding: var(--spacing-unit);
+}
+
+header, footer {
+  background: var(--header-bg);
+  padding: var(--spacing-unit);
+}
+
+@media (min-width: 600px) {
+  .nav-list {
+    justify-content: flex-end;
+  }
+}
+
+/* Utility classes */
+.u-hidden { display: none; }
+
+/* Print styles */
+@media print {
+  nav, footer { display: none; }
+}
+
+:focus-visible {
+  outline: 2px solid var(--link-color);
+}
+button {
+  padding: calc(var(--spacing-unit)/2) var(--spacing-unit);
+}
+
+input, textarea {
+  padding: calc(var(--spacing-unit)/2);
+  border: 1px solid #ccc;
+}
+
+.u-flex { display: flex; }

--- a/site/test.js
+++ b/site/test.js
@@ -1,0 +1,16 @@
+// Simple client-side test harness
+(function(){
+  console.log('Running smoke tests');
+  const toggle = document.getElementById('nav-toggle');
+  if (toggle) {
+    toggle.click();
+    console.assert(toggle.getAttribute('aria-expanded') === 'true', 'nav opens');
+    toggle.click();
+    console.assert(toggle.getAttribute('aria-expanded') === 'false', 'nav closes');
+  }
+  const collapsible = document.querySelector('[data-collapsible]');
+  if (collapsible) {
+    collapsible.click();
+    console.assert(collapsible.getAttribute('aria-expanded') === 'true', 'collapsible opens');
+  }
+})();


### PR DESCRIPTION
## Summary
- Add placeholder docs for IA, wireframes, components, and reviews
- Scaffold development and root site pages with metadata, navigation, and components
- Implement base CSS/JS, test harness, and prompt templates with promotion script

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8aed6659883238bcb0d0b2924c04f