### PR TITLE
Add dual license file for code and content

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,49 @@
+# FilmSeele: Finding Nemo License
+
+This project is dual-licensed under the terms below.
+
+## Code
+
+MIT License
+
+Copyright (c) 2025 Ben Wassa (GitHub: BenWassa)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Content
+
+The creative content of this project—including text, research briefs, site copy,
+podcast scripts, generated images, and other narrative works—is licensed under the
+Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International
+(CC BY-NC-ND 4.0) license.
+
+### Allowed
+- Share — copy and redistribute the material in any medium or format with attribution.
+
+### Not Allowed
+- Commercial use of the content.
+- Distributing modified versions of the content.
+
+**Attribution:** Please credit: Ben Wassa (GitHub: BenWassa).
+
+## Summary
+- Code is available under the MIT License.
+- Content is available under CC BY-NC-ND 4.0; you may share it with attribution but
+  not for commercial purposes and without modifications.
+- Please credit: Ben Wassa (GitHub: BenWassa).


### PR DESCRIPTION
## Summary
- add `LICENSE.md` documenting dual licensing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb0237108323a700b0bda6b295e6